### PR TITLE
[WIP]Group画面で起きた不具合の調整。

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -15,19 +15,30 @@ $(function() {
     function appendList(user) {
       var html = `<div class="chat-group-user clearfix">
                     <p class="chat-group-user__name">${ user.name }</p>
-                    <div class="user-search-add chat-group-user__btn chat-group-user__btn--add" id="${ user.id }" data-user-name="${ user.name }">追加</div>
+                    <div class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id="${ user.id }" data-user-name="${ user.name }">追加</div>
                   </div>`
       search_list.append(html)
     }
+
+    // function appendNolist() {
+    //   var html = `<div class="chat-group-user clearfix">
+    //                 <p class="chat-group-user__name">"一致するユーザーはいません"</p>
+    //               </div>`
+    //    $(search_list).empty() 
+    //   search_list.append(html)
+    //   $(search_list).empty() 
+    // }
+
 　　//検索後、選択されたユーザーをグループリストに追加
     function appendUser(user) {
       var html = `<div class='chat-group-user clearfix js-chat-member' id='newmember'>
-                    <input name='group[user_ids][]' type='hidden' value='${ user.name }'>
+                    <input name='group[user_ids][]' type='hidden' value='${ user.id }'>
                     <p class='chat-group-user__name'>${ user.name }</p>
                     <div class='user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn',id="delete">削除</div>
                   </div>`
       selected_list.append(html)
     }
+
 
     $(search_list).on("click", '.user-search-add', function() {
       appendUser(userdata);
@@ -53,18 +64,24 @@ $(function() {
       })
 
       .done(function(users) {
+
         if (word != preWord) {
           $(search_list).empty() 
-          if(users.length !== 0) {
-            //user検索し、合致するユーザーを表示。後にグループに追加するユーザーを選択する際に使うidにuser.idを指定
-          users.forEach(function(user) {
-            appendList(user);
-            userdata = user
-            //検索結果からユーザーを１人選択し、グループメンバーに追加。　ここでuser.idを指定したい。
-          });
-        }
-      }
-    })
+          //   if (input.length === 0) {
+          //    appendNolist();
+          //  }
+            if(users.length !== 0) {
+              //user検索し、合致するユーザーを表示。後にグループに追加するユーザーを選択する際に使うidにuser.idを指定
+              $.each(users, function(i, user) {
+                appendList(user);
+                userdata = user
+                //検索結果からユーザーを１人選択し、グループメンバーに追加。　ここでuser.idを指定したい。
+              });
+            }
+
+          }
+        preWord = word;
+      })
 
       .fail(function() {
         alert('ユーザー検索に失敗しました');

--- a/app/assets/stylesheets/modules/_group.scss
+++ b/app/assets/stylesheets/modules/_group.scss
@@ -1,3 +1,8 @@
+body{
+  overflow: scroll;
+}
+
+
 .chat-group-form {
   width: 980px;
   margin: 60px auto;
@@ -6,7 +11,7 @@
   border: 1px solid #ddd;
   border-radius: 5px;
   box-sizing: border-box;
-
+ 
   h1 {
     letter-spacing: 2px;
     font-size: 24px;

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -14,6 +14,7 @@ class GroupsController < ApplicationController
 
   def create
     @group = Group.new(group_params)
+    @group.users << current_user
     if @group.save
       redirect_to root_path, notice: 'グループを作成しました'
     else
@@ -23,6 +24,7 @@ class GroupsController < ApplicationController
 
   def update
     if @group.update(group_params)
+      @group.users << current_user
       redirect_to group_messages_path(@group), notice: 'グループを編集しました'
     else
       render :edit

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -17,7 +17,7 @@
       .chat-group-form__search.clearfix
         %input#user-search-field.chat-group-form__input{placeholder:  "追加したいユーザー名を入力してください", type: "text",name:  "keyword"}/
       #user-search-result
-      -# ここにメンバーが追加せれる
+
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
       %label.chat-group-form__label{for:  "chat_group_チャットメンバー"} チャットメンバー
@@ -25,7 +25,7 @@
       #chat-group-users
         #chat-group-user-22.chat-group-user.clearfix
           %input{name: "chat_group[user_ids][]", type:  "hidden", value:  "22"}/
-          %p.chat-group-user__name seo_kyohei誰？
+          %p.chat-group-user__name 
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right


### PR DESCRIPTION
# what
3点グループ画面において不具合が起きたので修正を行う
1.新規作成、編集グループ画面でグループを作った時、current_userが入らないのを修正。
2.新規作成、編集グループ画面で画面のスクロールができない。
3.グループ作成のインクリメンタルサーチのテキスト部分が何も打たなかったら全てのユーザーが表示される。

# why
より快適にグループ画面を使えるようにするため。
